### PR TITLE
fix(package.json) Use double quotes in "scripts" (cmd.exe)

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Starter project for an ES6 RESTful Express API",
   "main": "dist",
   "scripts": {
-    "dev": "nodemon -w src --exec 'babel-node src --presets es2015,stage-0'",
+    "dev": "nodemon -w src --exec \"babel-node src --presets es2015,stage-0\"",
     "build": "babel src -s -D -d dist --presets es2015,stage-0",
     "start": "node dist",
     "prestart": "npm run -s build",


### PR DESCRIPTION
OS: Windows 7
Node: v6.2.1
Npm: 3.10.5

Error:
[nodemon] starting `'babel-node src --presets es2015,stage-0'`
''babel-node' is not recognized as an internal or external command,
operable program or batch file.

Problem:
Single quotes are not used at all by the cmd.exe

Solution:
Replace single quotes to double quotes.