### PR TITLE
Fix "regeneratorRuntime is not defined" error

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,6 @@
+import "babel-core/register";
+import "babel-polyfill";
+
 import http from 'http';
 import express from 'express';
 import cors from 'cors';


### PR DESCRIPTION
This fixes the following error, which occurs when running `$ npm start` after `$ npm run build`:
```
ReferenceError: regeneratorRuntime is not defined
    at ...
    at Module._compile (module.js:641:30)
    at Object.Module._extensions..js (module.js:652:10)
    at Module.load (module.js:560:32)
    at tryModuleLoad (module.js:503:12)
    at Function.Module._load (module.js:495:3)
    at Module.require (module.js:585:17)
    at require (internal/module.js:11:18)
```