### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Getting Started
 
 ```sh
 # clone it
-git clone git@github.com:developit/express-es6-rest-api.git
+git clone https://github.com/developit/express-es6-rest-api.git
 cd express-es6-rest-api
 
 # Make it your own


### PR DESCRIPTION
ssh not work
I receive this error:

```
> $ git clone git@github.com:developit/express-es6-rest-api.git                                                                                                                                                                               
Cloning into 'express-es6-rest-api'...
Warning: Permanently added the RSA host key for IP address '192.30.253.113' to the list of known hosts.
Permission denied (publickey).
fatal: Could not read from remote repository.

Please make sure you have the correct access rights
and the repository exists.
```