### PR TITLE
Remove git.io usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This is a straightforward boilerplate for building REST APIs with ES6 and Expres
 - CORS support via [cors](https://github.com/troygoode/node-cors)
 - Body Parsing via [body-parser](https://github.com/expressjs/body-parser)
 
-> Tip: If you are using [Mongoose](https://github.com/Automattic/mongoose), you can automatically expose your Models as REST resources using [restful-mongoose](https://git.io/restful-mongoose).
+> Tip: If you are using [Mongoose](https://github.com/Automattic/mongoose), you can automatically expose your Models as REST resources using [restful-mongoose](https://github.com/developit/restful-mongoose).
 
 
 


### PR DESCRIPTION
See https://github.blog/changelog/2022-04-25-git-io-deprecation/.
